### PR TITLE
fix build against latest circt

### DIFF
--- a/lib/Dialect/Cosim/CosimOps.cpp
+++ b/lib/Dialect/Cosim/CosimOps.cpp
@@ -36,11 +36,12 @@ void cosim::CallOp::build(OpBuilder &odsBuilder, OperationState &state,
   state.addOperands(operands);
   state.addAttribute("func", func);
   state.addTypes(results);
-  state.addAttribute("ref", StringAttr::get(ref, ctx));
-
+  state.addAttribute("ref",
+                     StringAttr::get(ctx, std::string(ref.bytes().begin(),
+                                                      ref.bytes().end())));
   llvm::SmallVector<Attribute> targetsAttr;
   for (auto &target : targets)
-    targetsAttr.push_back(StringAttr::get(target, ctx));
+    targetsAttr.push_back(StringAttr::get(ctx, target));
 
   state.addAttribute("targets", ArrayAttr::get(ctx, targetsAttr));
 }

--- a/lib/Dialect/Cosim/Transforms/Passes.cpp
+++ b/lib/Dialect/Cosim/Transforms/Passes.cpp
@@ -394,7 +394,7 @@ struct ConvertStdCallPattern : OpRewritePattern<mlir::CallOp> {
       : OpRewritePattern(ctx), from(from), ref(ref), targets(targets) {}
   LogicalResult matchAndRewrite(mlir::CallOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op.callee() != from)
+    if (op.getCallee() != from)
       return failure();
 
     rewriter.replaceOpWithNewOp<cosim::CallOp>(op, op.getCalleeAttr(),
@@ -418,7 +418,7 @@ struct CosimConvertCallPass
     patterns.insert<ConvertStdCallPattern>(ctx, from, ref, targets);
     ConversionTarget target(*ctx);
     target.addDynamicallyLegalOp<mlir::CallOp>(
-        [&](mlir::CallOp callOp) { return callOp.callee() != from; });
+        [&](mlir::CallOp callOp) { return callOp.getCallee() != from; });
     target.addLegalDialect<cosim::CosimDialect>();
 
     if (failed(applyPartialConversion(getOperation(), target,


### PR DESCRIPTION
I had to fiddle to get `hls-opt` to compile against circt main (i.e., `bbe0104fcb1c67190c929c3da8ab2e9f8f0e33fd`). in general i'm not sure if you're pinning against some circt version...